### PR TITLE
Fixed an issue that causes a SyntaxError in python 3.6

### DIFF
--- a/lusmu/core.py
+++ b/lusmu/core.py
@@ -128,7 +128,7 @@ class BaseNode(object):
 
         """
         # test if neither, one of or both the old and the new value are DIRTY
-        dirty_count = len([v for v in value, self._value if v is DIRTY])
+        dirty_count = len([v for v in [value, self._value] if v is DIRTY])
         if dirty_count == 2:
             # both DIRTY, no need to touch anything
             return set()


### PR DESCRIPTION
`import lusmu.core` causes a SyntaxError exception in python 3.6

To replicate use python 3.6 and run:

```python
import lusmu.core
```